### PR TITLE
Fixed the issue of current user's name being included in the global challenges results name list

### DIFF
--- a/lib/screens/sideBar.dart
+++ b/lib/screens/sideBar.dart
@@ -76,7 +76,7 @@ class _SideBarState extends State<SideBar> {
   late ConfettiController _confettiController;
 
   final String firstName =
-      (SharedPrefs().getUserName() as String).replaceFirstMapped(
+      (SharedPrefs().getFirstName() as String).replaceFirstMapped(
     RegExp(r'^\w'),
     (match) => match
         .group(0)!

--- a/lib/screens/verbatastic.dart
+++ b/lib/screens/verbatastic.dart
@@ -45,6 +45,10 @@ class Verbatastic extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     preloadImages(context);
+    print("\n Verbanames before: ${verbatasticUsernames} \n");
+    verbatasticUsernames!.remove(SharedPrefs().getUserName() as String);
+    print("\n Verbanames after: ${verbatasticUsernames} \n");
+
     String copyIcon = 'assets/copy.svg';
     String sendIcon = 'assets/send.svg';
     String inviteText = "\n See how your friends would compare!";

--- a/lib/screens/verbatastic.dart
+++ b/lib/screens/verbatastic.dart
@@ -45,9 +45,8 @@ class Verbatastic extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     preloadImages(context);
-    print("\n Verbanames before: ${verbatasticUsernames} \n");
+    // Ensure the current user's username is not included in verbatasticUsernames
     verbatasticUsernames!.remove(SharedPrefs().getUserName() as String);
-    print("\n Verbanames after: ${verbatasticUsernames} \n");
 
     String copyIcon = 'assets/copy.svg';
     String sendIcon = 'assets/send.svg';


### PR DESCRIPTION
The issue I am talking about is this one: 
The current user's username is 'tayc':

![Screenshot 2024-02-19 192907](https://github.com/dartmouth-cs98-23f/verbatim_frontend/assets/97261557/1bdb371e-89e7-4dd9-bf18-6cbeff30d481)
![globalChallIssue](https://github.com/dartmouth-cs98-23f/verbatim_frontend/assets/97261557/87fd08ae-f117-49ac-83d9-f9e6f4b3f251)

If you notice that this issue still persists, please let me know.
